### PR TITLE
Allow INSTALL and PACKAGE to be built using a keyboard shortcut

### DIFF
--- a/modules/xpfunmac.cmake
+++ b/modules/xpfunmac.cmake
@@ -2201,6 +2201,9 @@ macro(xpCommonFlags)
     # Turn on Multi-processor Compilation
     xpStringAppendIfDne(CMAKE_C_FLAGS "/MP")
     xpStringAppendIfDne(CMAKE_CXX_FLAGS "/MP")
+    # Add INSTALL and PACKAGE to the default build configuration
+    set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)
+    set(CMAKE_VS_INCLUDE_PACKAGE_TO_DEFAULT_BUILD 1)
     # Remove /Zm1000 - breaks optimizing compiler w/ IncrediBuild
     string(REPLACE "/Zm1000" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
     string(REPLACE "/Zm1000" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})


### PR DESCRIPTION
I have a VS extension called `Build Only Startup Project` for assigning a keyboard shortcut that will build the startup project instead of whatever project I'm currently editing. I like to have INSTALL set as my startup project.

Currently, it does not work to try to build INSTALL with the hotkey:
![image](https://github.com/smanders/externpro/assets/14927087/c1498869-ed2b-4e89-ae96-392cd8621a4e)


For that hotkey to work, this box has to be checked:
![image](https://github.com/smanders/externpro/assets/14927087/f47c93cb-5c06-4af0-a772-d19435c867a7)

With that box checked, the build works properly:
![image](https://github.com/smanders/externpro/assets/14927087/2738ca28-69e4-4fc2-8a2e-d43521d8818e)


`ALL_BUILD` and `ZERO_CHECK` are already enabled, but `INSTALL`, `PACKAGE`, and `RUN_TESTS` are not enabled. It seems that `RUN_TESTS` can't be enabled through cmake and the others need to be enabled with these commands (well, they can be enabled manually, but that's no fun. And rerunning cmake will disable them.)

This location made the most sense to me as the proper spot to add these settings, which is why I put them here.